### PR TITLE
Improved handling of copy-paste events

### DIFF
--- a/experiments/e2e.ts
+++ b/experiments/e2e.ts
@@ -18,8 +18,8 @@ import {Person, School} from 'schema-dts';
 import {Transmat, TransmatObserver, addListeners} from '../src';
 import * as jsonLd from '../src/json_ld';
 
-const transmitEl = document.querySelector('.transmitter')!;
-const receiveEl = document.querySelector('.receiver')!;
+const transmitEl = document.querySelector<HTMLElement>('.transmitter')!;
+const receiveEl = document.querySelector<HTMLElement>('.receiver')!;
 
 addListeners(transmitEl, 'transmit', event => {
   const transfer = new Transmat(event);
@@ -34,13 +34,13 @@ addListeners(transmitEl, 'transmit', event => {
   transfer.setData(jsonLd.MIME_TYPE, data);
 });
 
-addListeners(receiveEl, 'receive', event => {
+addListeners(receiveEl, 'receive', (event, target) => {
   const transfer = new Transmat(event);
   if (transfer.hasType(jsonLd.MIME_TYPE) && transfer.accept()) {
     const person = jsonLd.parse<Person>(transfer.getData(jsonLd.MIME_TYPE)!);
     const school = jsonLd.getByType<School>(person, 'School')!;
     const message = `Hi ${person.name} from ${jsonLd.getValue(school.name)}`;
-    (event.target as HTMLElement).innerText = message;
+    target.innerText = message;
   }
 });
 

--- a/experiments/styles.css
+++ b/experiments/styles.css
@@ -21,14 +21,6 @@ body {
   margin: 5vh 5vw;
 }
 
-/**
- * At least in Chrome, when an element is set to draggable, user select is
- * disabled. Re-enable this to allow the user to copy/cut the data.
- */
-[draggable][tabindex] {
-  user-select: auto;
-}
-
 [draggable] {
   cursor: move;
 }

--- a/src/transmat.ts
+++ b/src/transmat.ts
@@ -109,8 +109,8 @@ export function addListeners<T extends Node>(
   options = {dragDrop: true, copyPaste: true}
 ): () => void {
   const isTransmitEvent = type === 'transmit';
-  let unlistenCopyPaste: undefined | (() => {});
-  let unlistenDragDrop: undefined | (() => {});
+  let unlistenCopyPaste: undefined | (() => void);
+  let unlistenDragDrop: undefined | (() => void);
 
   if (options.copyPaste) {
     const events = isTransmitEvent ? ['cut', 'copy'] : ['paste'];

--- a/src/transmat.ts
+++ b/src/transmat.ts
@@ -102,28 +102,42 @@ export type TransferEventType = 'transmit' | 'receive';
  * Setup listeners. Returns a function to remove the event listeners.
  * Optionally you can change the event types that will be listened to.
  */
-export function addListeners(
-  target: EventTarget,
+export function addListeners<T extends Node>(
+  target: T,
   type: TransferEventType,
-  listener: (event: DataTransferEvent) => void,
+  listener: (event: DataTransferEvent, target: T) => void,
   options = {dragDrop: true, copyPaste: true}
 ): () => void {
-  // Pick the events to listen to.
-  const eventTypes: string[] = [];
-  if (type === 'transmit') {
-    if (options.dragDrop) eventTypes.push('dragstart');
-    if (options.copyPaste) eventTypes.push('cut', 'copy');
-  } else {
-    if (options.dragDrop) eventTypes.push('dragover', 'drop');
-    if (options.copyPaste) eventTypes.push('paste');
-  }
-  return addEventListeners(target, eventTypes, event => {
-    listener(event as DataTransferEvent);
+  const isTransmitEvent = type === 'transmit';
+  let unlistenCopyPaste: undefined | (() => {});
+  let unlistenDragDrop: undefined | (() => {});
 
-    // The default behavior of copy and cut needs to be prevented, otherwise
-    // DataTransfer won't work.
-    if (options.copyPaste && (event.type === 'copy' || event.type === 'cut')) {
-      event.preventDefault();
-    }
-  });
+  if (options.copyPaste) {
+    const events = isTransmitEvent ? ['cut', 'copy'] : ['paste'];
+    const parentElement = target.parentElement!;
+    unlistenCopyPaste = addEventListeners(parentElement, events, event => {
+      if (!target.contains(document.activeElement)) {
+        return;
+      }
+      listener(event as DataTransferEvent, target);
+
+      // The default behavior of copy and cut needs to be prevented, otherwise
+      // DataTransfer won't work.
+      if (event.type === 'copy' || event.type === 'cut') {
+        event.preventDefault();
+      }
+    });
+  }
+
+  if (options.dragDrop) {
+    const events = isTransmitEvent ? ['dragstart'] : ['dragover', 'drop'];
+    unlistenDragDrop = addEventListeners(target, events, event => {
+      listener(event as DataTransferEvent, target);
+    });
+  }
+
+  return () => {
+    unlistenCopyPaste && unlistenCopyPaste();
+    unlistenDragDrop && unlistenDragDrop();
+  };
 }


### PR DESCRIPTION
Listen to copy-paste events on the parent node. This adds a second argument to the listener callback with the target.